### PR TITLE
Fix syncing exchange rates on startup (#147)

### DIFF
--- a/BankWallet/BankWallet/Core/App.swift
+++ b/BankWallet/BankWallet/Core/App.swift
@@ -91,7 +91,7 @@ class App {
         rateSyncer.delegate = rateManager
 
         transactionRateSyncer = TransactionRateSyncer(storage: realmStorage, networkManager: networkManager)
-        transactionManager = TransactionManager(storage: realmStorage, rateSyncer: transactionRateSyncer, walletManager: walletManager, currencyManager: currencyManager, wordsManager: wordsManager)
+        transactionManager = TransactionManager(storage: realmStorage, rateSyncer: transactionRateSyncer, walletManager: walletManager, currencyManager: currencyManager, wordsManager: wordsManager, reachabilityManager: reachabilityManager)
 
         transactionViewItemFactory = TransactionViewItemFactory(walletManager: walletManager, currencyManager: currencyManager)
     }

--- a/BankWallet/BankWallet/Core/Managers/AppConfigProvider.swift
+++ b/BankWallet/BankWallet/Core/Managers/AppConfigProvider.swift
@@ -2,6 +2,7 @@ import Foundation
 
 class AppConfigProvider: IAppConfigProvider {
 
+    let reachabilityHost = "ipfs.horizontalsystems.xyz"
     let ratesApiUrl = "https://ipfs.horizontalsystems.xyz/ipns/Qmd4Gv2YVPqs6dmSy1XEq7pQRSgLihqYKL2JjK7DMUFPVz/io-hs/data/xrates"
 
     var enabledCoins: [Coin] {

--- a/BankWallet/BankWallet/Core/Managers/RateManager.swift
+++ b/BankWallet/BankWallet/Core/Managers/RateManager.swift
@@ -10,7 +10,6 @@ class RateManager {
     private let syncer: IRateSyncer
     private let walletManager: IWalletManager
     private let currencyManager: ICurrencyManager
-    private let reachabilityManager: IReachabilityManager
     private var timer: IPeriodicTimer
 
     init(storage: IRateStorage, syncer: IRateSyncer, walletManager: IWalletManager, currencyManager: ICurrencyManager, reachabilityManager: IReachabilityManager, timer: IPeriodicTimer) {
@@ -18,7 +17,6 @@ class RateManager {
         self.syncer = syncer
         self.walletManager = walletManager
         self.currencyManager = currencyManager
-        self.reachabilityManager = reachabilityManager
         self.timer = timer
 
         self.timer.delegate = self

--- a/BankWallet/BankWallet/Core/Managers/ReachabilityManager.swift
+++ b/BankWallet/BankWallet/Core/Managers/ReachabilityManager.swift
@@ -7,7 +7,7 @@ class ReachabilityManager {
     let manager: NetworkReachabilityManager?
 
     init(appConfigProvider: IAppConfigProvider) {
-        manager = NetworkReachabilityManager(host: appConfigProvider.ratesApiUrl)
+        manager = NetworkReachabilityManager(host: appConfigProvider.reachabilityHost)
 
         manager?.listener = { [weak self] status in
             switch status {

--- a/BankWallet/BankWallet/Core/Protocols.swift
+++ b/BankWallet/BankWallet/Core/Protocols.swift
@@ -163,6 +163,7 @@ protocol ISystemInfoManager {
 }
 
 protocol IAppConfigProvider {
+    var reachabilityHost: String { get }
     var ratesApiUrl: String { get }
     var enabledCoins: [Coin] { get }
     var currencies: [Currency] { get }


### PR DESCRIPTION
- use separate reachability host app config instead of using url. This is required for Alamofire Reachability manager to work correctly.
- add reachability trigger for syncing transaction rates in TransactionManager.

Closes #147 