### PR TITLE
Fix cyclic reference issue with Wallet objects (#182)

### DIFF
--- a/BankWallet/BankWallet/Core/Managers/TransactionManager.swift
+++ b/BankWallet/BankWallet/Core/Managers/TransactionManager.swift
@@ -79,6 +79,7 @@ class TransactionManager {
     }
 
     private func clear() {
+        adaptersDisposeBag = DisposeBag()
         storage.clearRecords()
     }
 


### PR DESCRIPTION
- TransactionManager subscription to adapters was not disposed on clear.

Closes #182 