### PR TITLE
Use latest rate for recent transactions (#187)

### DIFF
--- a/BankWallet/BankWallet/Core/Adapters/BitcoinAdapter.swift
+++ b/BankWallet/BankWallet/Core/Adapters/BitcoinAdapter.swift
@@ -37,7 +37,7 @@ class BitcoinAdapter {
         record.transactionHash = transaction.transactionHash
         record.blockHeight = transaction.blockHeight ?? 0
         record.amount = Double(transaction.amount) / coinRate
-        record.timestamp = transaction.timestamp ?? Int(Date().timeIntervalSince1970)
+        record.timestamp = transaction.timestamp.map { Double($0) } ?? Date().timeIntervalSince1970
 
         transaction.from.forEach {
             let address = TransactionAddress()

--- a/BankWallet/BankWallet/Core/Adapters/EthereumAdapter.swift
+++ b/BankWallet/BankWallet/Core/Adapters/EthereumAdapter.swift
@@ -41,7 +41,7 @@ class EthereumAdapter {
         record.transactionHash = transaction.txHash
         record.blockHeight = transaction.blockNumber
         record.amount = amountEther * (from.mine ? -1 : 1)
-        record.timestamp = transaction.timestamp
+        record.timestamp = Double(transaction.timestamp)
 
         record.from.append(from)
         record.to.append(to)

--- a/BankWallet/BankWallet/Core/App.swift
+++ b/BankWallet/BankWallet/Core/App.swift
@@ -50,12 +50,7 @@ class App {
     init() {
         pasteboardManager = PasteboardManager()
 
-        let realmFileName = "bank.realm"
-
-        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        let realmConfiguration = Realm.Configuration(fileURL: documentsUrl?.appendingPathComponent(realmFileName))
-
-        realmFactory = RealmFactory(configuration: realmConfiguration)
+        realmFactory = RealmFactory()
 
         localStorage = UserDefaultsStorage()
         secureStorage = KeychainStorage(localStorage: localStorage)
@@ -93,7 +88,7 @@ class App {
         transactionRateSyncer = TransactionRateSyncer(storage: realmStorage, networkManager: networkManager)
         transactionManager = TransactionManager(storage: realmStorage, rateSyncer: transactionRateSyncer, walletManager: walletManager, currencyManager: currencyManager, wordsManager: wordsManager, reachabilityManager: reachabilityManager)
 
-        transactionViewItemFactory = TransactionViewItemFactory(walletManager: walletManager, currencyManager: currencyManager)
+        transactionViewItemFactory = TransactionViewItemFactory(walletManager: walletManager, currencyManager: currencyManager, rateManager: rateManager)
     }
 
 }

--- a/BankWallet/BankWallet/Core/Storage/RealmFactory.swift
+++ b/BankWallet/BankWallet/Core/Storage/RealmFactory.swift
@@ -3,8 +3,29 @@ import RealmSwift
 class RealmFactory {
     private let configuration: Realm.Configuration
 
-    init(configuration: Realm.Configuration) {
-        self.configuration = configuration
+    init() {
+        let realmFileName = "bank.realm"
+        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+
+        configuration = Realm.Configuration(
+                fileURL: documentsUrl?.appendingPathComponent(realmFileName),
+                schemaVersion: 1,
+                migrationBlock: { migration, oldSchemaVersion in
+
+                    if (oldSchemaVersion < 1) {
+                        migration.enumerateObjects(ofType: TransactionRecord.className()) { oldObject, newObject in
+                            let oldTimestamp = oldObject!["timestamp"] as! Int
+                            newObject!["timestamp"] = Double(oldTimestamp)
+                        }
+                    }
+
+                },
+                objectTypes: [
+                    TransactionRecord.self,
+                    TransactionAddress.self,
+                    Rate.self
+                ]
+        )
     }
 
 }

--- a/BankWallet/BankWallet/Models/TransactionRecord.swift
+++ b/BankWallet/BankWallet/Models/TransactionRecord.swift
@@ -5,7 +5,7 @@ class TransactionRecord: Object {
     @objc dynamic var blockHeight: Int = 0
     @objc dynamic var coin: String = ""
     @objc dynamic var amount: Double = 0
-    @objc dynamic var timestamp: Int = 0
+    @objc dynamic var timestamp: Double = 0
     @objc dynamic var rate: Double = 0
 
     let from = List<TransactionAddress>()

--- a/BankWallet/BankWalletTests/Core/Managers/TransactionRateSyncerTests.swift
+++ b/BankWallet/BankWalletTests/Core/Managers/TransactionRateSyncerTests.swift
@@ -19,8 +19,8 @@ class TransactionRateSyncerTests: XCTestCase {
     private let etherHash = "Ether Hash"
     private let cashHash = "Cash Hash"
 
-    private let bitcoinTimestamp = 1000
-    private let etherTimestamp = 2000
+    private let bitcoinTimestamp: Double = 1000
+    private let etherTimestamp: Double = 2000
 
     private let bitcoinValue: Double = 5000
     private let etherValue: Double = 300

--- a/BankWallet/BankWalletTests/TestExtensions.swift
+++ b/BankWallet/BankWalletTests/TestExtensions.swift
@@ -41,7 +41,7 @@ extension TransactionFilterItem: Equatable {
 }
 
 extension TransactionRecord {
-    convenience init(transactionHash: String, coin: String, timestamp: Int) {
+    convenience init(transactionHash: String, coin: String, timestamp: Double) {
         self.init()
 
         self.transactionHash = transactionHash

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -113,10 +113,10 @@ CHECKOUT OPTIONS:
     :commit: 852780b5548f639b3e63cce2a353c3a4d4cf6348
     :git: https://github.com/horizontalsystems/GrouviHUD.git
   HSBitcoinKit:
-    :commit: 55d766d7757571fd9f49710bdd8097d2ff418b8a
+    :commit: bcd29caf0667af49a494e8e430dab608f3dec3a2
     :git: https://github.com/horizontalsystems/bitcoin-kit-ios.git
   HSEthereumKit:
-    :commit: 85fae266081dee9f9731295c6b1c2ff93d67685f
+    :commit: fc6d5a517b505b4025244d3d23f3f01c1131cf8d
     :git: https://github.com/horizontalsystems/ethereum-kit-ios.git
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
- use latest rate from RateManager if it is not expired and transaction timestamp is within an hour
- change timestamp field for TransactionRecord from Int to Double

Closes #187 