### PR TITLE
Refactor custom NumPad control (#110)

### DIFF
--- a/BankWallet/BankWallet.xcodeproj/project.pbxproj
+++ b/BankWallet/BankWallet.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		11B354D04599199832DDAC94 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35A5DE20DD6DD486FAFC0 /* Protocols.swift */; };
 		11B354D394895E1FAFB2F116 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3535DD03F9264351E13A9 /* NetworkManager.swift */; };
 		11B354E052C02470D2DB1F92 /* TransactionsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35BEF7ABBE155593B4DBE /* TransactionsInteractor.swift */; };
+		11B354E2E53DB96607574EA1 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3572B7C2F16CD51F37FF0 /* UIImage.swift */; };
 		11B35526BED48D17B07C3C46 /* ValueFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35EFB45ECC2D403CA6C89 /* ValueFormatter.swift */; };
 		11B35530C3166434FDD263FF /* SendConfirmationValueItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3572D1DA38AAD1A4429EB /* SendConfirmationValueItem.swift */; };
 		11B3553FE441E814B14A29F6 /* KeyboardObservingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3535FC407BA20765EBCF4 /* KeyboardObservingViewController.swift */; };
@@ -91,6 +92,7 @@
 		11B35687D13433591FF7F037 /* AppConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B358A2ED820E5741F0701A /* AppConfigProvider.swift */; };
 		11B356949FB74ACE63ABB6E0 /* GuestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B353D57AB36A9CF4DEE090 /* GuestViewController.swift */; };
 		11B356ACDE9648AB1D98B466 /* BaseCurrencySettingsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3550630A9EC44B7157E6F /* BaseCurrencySettingsInteractor.swift */; };
+		11B356ACF29311C0C85E1841 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B351E743E45282859B08D3 /* UIButton.swift */; };
 		11B356B01A92AFE22DDB8754 /* SendConfirmationAmounItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B350EB27AD6B432BD7DCD1 /* SendConfirmationAmounItem.swift */; };
 		11B356CA54463B4740A9E3AA /* BaseCurrencySettingsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3550630A9EC44B7157E6F /* BaseCurrencySettingsInteractor.swift */; };
 		11B356D2F4655ACA22659DA2 /* SendConfirmationAmountItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B356AA9A3DDA541D5EBEAC /* SendConfirmationAmountItemView.swift */; };
@@ -109,6 +111,7 @@
 		11B358174F4EECAD3CE3F293 /* BaseCurrencySettingsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35B7A44754508AEFDA9FD /* BaseCurrencySettingsPresenter.swift */; };
 		11B3581B212DB1B428F85501 /* Rate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35BBAAAE1A3981B902E89 /* Rate.swift */; };
 		11B3581B5F15B9F806F1CA8F /* BaseCurrencySettingsPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B359DA37B619C35AF93D2A /* BaseCurrencySettingsPresenterTests.swift */; };
+		11B3581D452FC3D2569BBA71 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B351E743E45282859B08D3 /* UIButton.swift */; };
 		11B35848297F392FE9F72BF2 /* SendStateViewItemFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35072A029200FB9F86BCB /* SendStateViewItemFactory.swift */; };
 		11B3584F38352B045CCBE958 /* BaseCurrencySettingsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3550630A9EC44B7157E6F /* BaseCurrencySettingsInteractor.swift */; };
 		11B35891D2B5448227630380 /* SendInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35FAF942FA80752EDBFA7 /* SendInteractorTests.swift */; };
@@ -167,6 +170,7 @@
 		11B35BCC6C00E857CE562F16 /* EthereumAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B352D314A298B6B832F309 /* EthereumAdapter.swift */; };
 		11B35BCEC18400181DF64491 /* RestoreRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35142DB758C8B2397D115 /* RestoreRouter.swift */; };
 		11B35BD066A268FB1B85B068 /* PasteboardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35CEBC4B32E57AA2469AA /* PasteboardManager.swift */; };
+		11B35BDBD856C645045553D2 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3572B7C2F16CD51F37FF0 /* UIImage.swift */; };
 		11B35BDC437435B4EE7D9CED /* BaseCurrencySettingsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35F3E6B957ECFF5D1CE2E /* BaseCurrencySettingsRouter.swift */; };
 		11B35BE00F8891F220DECB76 /* SendConfirmationAddressItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3522F9D6DB1D04EA92CCE /* SendConfirmationAddressItem.swift */; };
 		11B35BE6009ABF3DF47A80BA /* RealmStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B354A7AB2C1276AAAAE9E6 /* RealmStorage.swift */; };
@@ -184,11 +188,13 @@
 		11B35CCCC38E551EBFD67DA9 /* SendFeeItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3550B7B94CDF3DA89DBF1 /* SendFeeItemView.swift */; };
 		11B35CE4290254DCFF1D76A5 /* UnlinkButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3595B61F6978D745D9776 /* UnlinkButtonItem.swift */; };
 		11B35CE6041F88972EBB3CDE /* CurrencyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3589DC1945CAFBEEB1EED /* CurrencyValue.swift */; };
+		11B35D0542ACB56A31C61143 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3572B7C2F16CD51F37FF0 /* UIImage.swift */; };
 		11B35D0A9EA408E35FF7062F /* CurrencyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3598F5529D0939EE53A19 /* CurrencyManager.swift */; };
 		11B35D1E39102FA5DAA9F974 /* LaunchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35C7DCF9B7894F7600623 /* LaunchRouter.swift */; };
 		11B35D77A40B7BCA0F7D4ECE /* SendPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35DC75FCA42F7A5FB1E65 /* SendPresenterTests.swift */; };
 		11B35D891416C66FA7FAD434 /* AboutSettingsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35BDC4FD741BE033D1956 /* AboutSettingsRouter.swift */; };
 		11B35D9074EB55CC9CACE405 /* CurrencyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3598F5529D0939EE53A19 /* CurrencyManager.swift */; };
+		11B35D96561FFB5973987D75 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B351E743E45282859B08D3 /* UIButton.swift */; };
 		11B35DA379AE43A774D84246 /* BackupModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B356CEB7192CE21DD1BC8B /* BackupModule.swift */; };
 		11B35DB8BF076EECADC5274E /* SendConfirmationAddressItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3543C6E6212154344AD63 /* SendConfirmationAddressItemView.swift */; };
 		11B35DC7196107932FE4F0DE /* PeriodicTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35FA1C1FF965AA2EB6666 /* PeriodicTimer.swift */; };
@@ -827,6 +833,7 @@
 		11B351C72700B40AB457AFA8 /* TestExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestExtensions.swift; sourceTree = "<group>"; };
 		11B351D1EA6877358DABA00F /* DepositInteractorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DepositInteractorTests.swift; sourceTree = "<group>"; };
 		11B351D55B31D37B7194DE55 /* UITableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableView.swift; sourceTree = "<group>"; };
+		11B351E743E45282859B08D3 /* UIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
 		11B351FFC025462BB9F01184 /* UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		11B352044BCE494491257933 /* UserDefaultsStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsStorage.swift; sourceTree = "<group>"; };
 		11B3520E9F70FFB8CC2D25A3 /* TransactionsRouter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionsRouter.swift; sourceTree = "<group>"; };
@@ -869,6 +876,7 @@
 		11B356DF243F6B9248E6AD42 /* Currency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		11B356FC36735ABABB140C33 /* TransactionRateSyncer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionRateSyncer.swift; sourceTree = "<group>"; };
 		11B3570598EDE26F96BC5F41 /* RespondButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RespondButton.swift; sourceTree = "<group>"; };
+		11B3572B7C2F16CD51F37FF0 /* UIImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		11B3572D1DA38AAD1A4429EB /* SendConfirmationValueItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendConfirmationValueItem.swift; sourceTree = "<group>"; };
 		11B3576492DE68F2507BB711 /* AdapterFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdapterFactory.swift; sourceTree = "<group>"; };
 		11B357776F706C10E8B14C4E /* TransactionViewItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionViewItem.swift; sourceTree = "<group>"; };
@@ -1237,6 +1245,8 @@
 				11B355ABE89C2793563829BD /* Date.swift */,
 				11B356D6300E64A1982BC9EB /* UIAlertController.swift */,
 				11B351D55B31D37B7194DE55 /* UITableView.swift */,
+				11B351E743E45282859B08D3 /* UIButton.swift */,
+				11B3572B7C2F16CD51F37FF0 /* UIImage.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2778,6 +2788,8 @@
 				58AAA1AB2FD9FBA7801F830D /* PaymentRequestAddress.swift in Sources */,
 				11B35356482DC7860F552715 /* NumPad.swift in Sources */,
 				11B35669B7CAC5A76825BD9C /* NumPadTheme.swift in Sources */,
+				11B3581D452FC3D2569BBA71 /* UIButton.swift in Sources */,
+				11B354E2E53DB96607574EA1 /* UIImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3059,6 +3071,8 @@
 				58AAA8D40B3399937CFEB0F2 /* PaymentRequestAddress.swift in Sources */,
 				11B35DD248A04320CF13BCA2 /* NumPad.swift in Sources */,
 				11B35EF16E8F5AEE9336AE30 /* NumPadTheme.swift in Sources */,
+				11B35D96561FFB5973987D75 /* UIButton.swift in Sources */,
+				11B35BDBD856C645045553D2 /* UIImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3302,6 +3316,8 @@
 				58AAA4E1C32E0B48A4CFECCD /* PaymentRequestAddress.swift in Sources */,
 				11B35942007821FA754B0ACE /* NumPad.swift in Sources */,
 				11B35075ECB2F181418CD3A8 /* NumPadTheme.swift in Sources */,
+				11B356ACF29311C0C85E1841 /* UIButton.swift in Sources */,
+				11B35D0542ACB56A31C61143 /* UIImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BankWallet/BankWallet/Theme/ButtonTheme.swift
+++ b/BankWallet/BankWallet/Theme/ButtonTheme.swift
@@ -28,8 +28,6 @@ class ButtonTheme {
     static let textColorOnDarkBackgroundDictionary: RespondButton.Style = [.active: ButtonTheme.textColor, .selected: ButtonTheme.textColor, .disabled: ButtonTheme.textColorDisabledOnDarkBackground]
     static let whiteTextColorOnDarkBackgroundDictionary: RespondButton.Style = [.active: .white, .selected: .white, .disabled: ButtonTheme.textColorDisabledOnWhiteBackground]
 
-    static let numPadBackgroundDictionary: RespondButton.Style = [.active: .crypto_Steel20_White, .selected: .crypto_Steel20_Steel40, .disabled: .cryptoSteel20]
-
     static let font = UIFont.cryptoHeadline
     static let margin: CGFloat = 16
 }

--- a/BankWallet/BankWallet/Theme/NumPadTheme.swift
+++ b/BankWallet/BankWallet/Theme/NumPadTheme.swift
@@ -1,14 +1,16 @@
 import UIKit
 
 class NumPadTheme {
-    static var width: CGFloat = 276
-    static var height: CGFloat = 308
+    static var size: CGSize = CGSize(width: 276, height: 308)
     static var spacing: CGFloat = 12
 
     static var itemSize: CGSize = CGSize(width: 84, height: 68)
     static var itemBorderWidth: CGFloat = 1
     static var itemBorderColor: UIColor = .cryptoSteel40
     static var itemCornerRadius: CGFloat = 16
+
+    static var buttonBackgroundColor: UIColor = .crypto_Steel20_White
+    static var buttonBackgroundColorHighlighted: UIColor = .crypto_Steel20_Steel40
 
     static var numberFont: UIFont = .systemFont(ofSize: 30)
     static var numberColor: UIColor = .crypto_White_Black

--- a/BankWallet/BankWallet/UserInterface/Controls/NumPad.swift
+++ b/BankWallet/BankWallet/UserInterface/Controls/NumPad.swift
@@ -3,15 +3,15 @@ import SnapKit
 
 class NumPad: UICollectionView {
 
-    enum Cell {
+    private enum Cell {
         case number(number: String, letters: String?, action: () -> ())
         case image(image: UIImage?, pressedImage: UIImage?, action: (() -> ())?)
     }
 
     weak var numPadDelegate: NumPadDelegate?
-    let layout = UICollectionViewFlowLayout()
+    private let layout = UICollectionViewFlowLayout()
 
-    var cells = [Cell]()
+    private var cells = [Cell]()
 
     init() {
         super.init(frame: .zero, collectionViewLayout: layout)
@@ -31,8 +31,7 @@ class NumPad: UICollectionView {
         isScrollEnabled = false
 
         snp.makeConstraints { maker in
-            maker.width.equalTo(NumPadTheme.width)
-            maker.height.equalTo(NumPadTheme.height)
+            maker.size.equalTo(NumPadTheme.size)
         }
 
         cells = [
@@ -95,22 +94,23 @@ extension NumPad: UICollectionViewDelegate {
 
 class NumPadNumberCell: UICollectionViewCell {
 
-    let button = RespondButton()
-    let numberLabel = UILabel()
-    let lettersLabel = UILabel()
+    private let button = UIButton()
+    private let numberLabel = UILabel()
+    private let lettersLabel = UILabel()
+    private var onTap: (() -> ())?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
         button.borderWidth = NumPadTheme.itemBorderWidth
         button.borderColor = NumPadTheme.itemBorderColor
-        button.titleLabel.removeFromSuperview()
+        button.cornerRadius = NumPadTheme.itemCornerRadius
+        button.setBackgroundColor(color: NumPadTheme.buttonBackgroundColor, forState: .normal)
+        button.setBackgroundColor(color: NumPadTheme.buttonBackgroundColorHighlighted, forState: .highlighted)
         addSubview(button)
         button.snp.makeConstraints { maker in
             maker.edges.equalToSuperview()
         }
-        button.cornerRadius = NumPadTheme.itemCornerRadius
-        button.backgrounds = ButtonTheme.numPadBackgroundDictionary
 
         numberLabel.font = NumPadTheme.numberFont
         numberLabel.textColor = NumPadTheme.numberColor
@@ -123,6 +123,8 @@ class NumPadNumberCell: UICollectionViewCell {
             maker.centerX.equalToSuperview()
             maker.bottom.equalToSuperview().offset(-NumPadTheme.lettersBottomMargin)
         }
+
+        button.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -132,7 +134,7 @@ class NumPadNumberCell: UICollectionViewCell {
     func bind(number: String, letters: String?, onTap: @escaping () -> ()) {
         numberLabel.text = number
         lettersLabel.text = letters
-        button.onTap = onTap
+        self.onTap = onTap
 
         lettersLabel.isHidden = letters == nil
 
@@ -147,12 +149,16 @@ class NumPadNumberCell: UICollectionViewCell {
         }
     }
 
+    @objc func didTapButton() {
+        onTap?()
+    }
+
 }
 
 class NumPadImageCell: UICollectionViewCell {
 
-    let button = UIButton()
-    var onTap: (() -> ())?
+    private let button = UIButton()
+    private var onTap: (() -> ())?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -177,18 +183,6 @@ class NumPadImageCell: UICollectionViewCell {
 
     @objc func didTapButton() {
         onTap?()
-    }
-
-}
-
-extension UIImage {
-
-    func tinted(with color: UIColor) -> UIImage? {
-        UIGraphicsBeginImageContextWithOptions(size, false, scale)
-        defer { UIGraphicsEndImageContext() }
-        color.set()
-        withRenderingMode(.alwaysTemplate).draw(in: CGRect(origin: .zero, size: size))
-        return UIGraphicsGetImageFromCurrentImageContext()
     }
 
 }

--- a/BankWallet/BankWallet/UserInterface/Extensions/UIButton.swift
+++ b/BankWallet/BankWallet/UserInterface/Extensions/UIButton.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+extension UIButton {
+
+    func setBackgroundColor(color: UIColor, forState state: UIControl.State) {
+        self.clipsToBounds = true  // add this to maintain corner radius
+
+        UIGraphicsBeginImageContext(CGSize(width: 1, height: 1))
+
+        if let context = UIGraphicsGetCurrentContext() {
+            context.setFillColor(color.cgColor)
+            context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+            let colorImage = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+
+            setBackgroundImage(colorImage, for: state)
+        }
+    }
+
+}

--- a/BankWallet/BankWallet/UserInterface/Extensions/UIImage.swift
+++ b/BankWallet/BankWallet/UserInterface/Extensions/UIImage.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+extension UIImage {
+
+    func tinted(with color: UIColor) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+
+        defer { UIGraphicsEndImageContext() }
+
+        color.set()
+        withRenderingMode(.alwaysTemplate).draw(in: CGRect(origin: .zero, size: size))
+
+        return UIGraphicsGetImageFromCurrentImageContext()
+    }
+
+}


### PR DESCRIPTION
- use default UIButton instead of RespondButton (not necessary)
- extract extensions to UI controls to separate files