### PR TITLE
Fix localization issue with Back button (#383)

### DIFF
--- a/BankWallet/BankWallet/Modules/Backup/BackupIntroController.swift
+++ b/BankWallet/BankWallet/Modules/Backup/BackupIntroController.swift
@@ -24,6 +24,7 @@ class BackupIntroController: UIViewController {
         view.backgroundColor = AppTheme.controllerBackground
 
         title = "backup.intro.title".localized
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
 
         laterButton?.setBackgroundColor(color: BackupTheme.laterButtonBackground, forState: .normal)
         subtitleLabel?.text = "backup.intro.subtitle".localized

--- a/BankWallet/BankWallet/Modules/Backup/BackupWordsController.swift
+++ b/BankWallet/BankWallet/Modules/Backup/BackupWordsController.swift
@@ -5,7 +5,6 @@ class BackupWordsController: UIViewController {
     let delegate: IBackupViewDelegate
 
     @IBOutlet weak var wordsLabel: UILabel?
-    @IBOutlet weak var backButton: UIButton?
     @IBOutlet weak var proceedButton: UIButton?
 
     let words: [String]
@@ -27,8 +26,8 @@ class BackupWordsController: UIViewController {
         view.backgroundColor = AppTheme.controllerBackground
 
         title = "backup.words.title".localized
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
 
-        backButton?.setTitle("backup.words.back".localized, for: .normal)
         proceedButton?.setTitle("backup.words.proceed".localized, for: .normal)
 
         let joinedWords = words.enumerated().map { "\($0 + 1). \($1)" }.joined(separator: "\n")

--- a/BankWallet/BankWallet/Modules/FullTransactionInfo/FullTransactionInfoRouter.swift
+++ b/BankWallet/BankWallet/Modules/FullTransactionInfo/FullTransactionInfoRouter.swift
@@ -51,6 +51,7 @@ extension FullTransactionInfoRouter {
         let navigationController = UINavigationController(rootViewController: viewController)
         navigationController.navigationBar.tintColor = AppTheme.navigationBarTintColor
         navigationController.navigationBar.barStyle = AppTheme.navigationBarStyle
+        navigationController.navigationBar.prefersLargeTitles = true
 
         router.viewController = navigationController
         return navigationController

--- a/BankWallet/BankWallet/Modules/FullTransactionInfo/FullTransactionInfoViewController.swift
+++ b/BankWallet/BankWallet/Modules/FullTransactionInfo/FullTransactionInfoViewController.swift
@@ -39,7 +39,9 @@ class FullTransactionInfoViewController: UIViewController, SectionsDataSource {
         super.viewDidLoad()
 
         view.backgroundColor = AppTheme.controllerBackground
+
         title = "full_info.title".localized
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: title, style: .plain, target: nil, action: nil)
 
         view.addSubview(tableView)
         tableView.backgroundColor = .clear
@@ -121,7 +123,6 @@ class FullTransactionInfoViewController: UIViewController, SectionsDataSource {
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        navigationController?.navigationBar.prefersLargeTitles = false
         tableView.deselectCell(withCoordinator: transitionCoordinator, animated: animated)
     }
 

--- a/BankWallet/BankWallet/Modules/Settings/Main/MainSettingsModule.swift
+++ b/BankWallet/BankWallet/Modules/Settings/Main/MainSettingsModule.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 protocol IMainSettingsView: class {
-    func set(title: String)
     func set(backedUp: Bool)
     func set(baseCurrency: String)
     func set(language: String)

--- a/BankWallet/BankWallet/Modules/Settings/Main/MainSettingsPresenter.swift
+++ b/BankWallet/BankWallet/Modules/Settings/Main/MainSettingsPresenter.swift
@@ -16,8 +16,6 @@ class MainSettingsPresenter {
 extension MainSettingsPresenter: IMainSettingsViewDelegate {
 
     func viewDidLoad() {
-        view?.set(title: "settings.title")
-
         view?.set(backedUp: interactor.isBackedUp)
         view?.set(baseCurrency: interactor.baseCurrency)
         view?.set(language: interactor.currentLanguage)

--- a/BankWallet/BankWallet/Modules/Settings/Main/MainSettingsViewController.swift
+++ b/BankWallet/BankWallet/Modules/Settings/Main/MainSettingsViewController.swift
@@ -21,6 +21,9 @@ class MainSettingsViewController: UIViewController, SectionsDataSource {
 
         super.init(nibName: nil, bundle: nil)
 
+        title = "settings.title".localized
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: title, style: .plain, target: nil, action: nil)
+
         tabBarItem = UITabBarItem(title: "settings.tab_bar_item".localized, image: UIImage(named: "settings.tab_bar_item"), tag: 0)
 
         tableView.registerCell(forClass: SettingsCell.self)
@@ -149,11 +152,6 @@ class MainSettingsViewController: UIViewController, SectionsDataSource {
 }
 
 extension MainSettingsViewController: IMainSettingsView {
-
-    func set(title: String) {
-        self.title = title.localized
-        reloadIfNeeded()
-    }
 
     func set(backedUp: Bool) {
         self.backedUp = backedUp

--- a/BankWallet/BankWallet/en.lproj/Localizable.strings
+++ b/BankWallet/BankWallet/en.lproj/Localizable.strings
@@ -43,7 +43,6 @@ Go to Settings - > Bank and allow access to Camera.";
 "backup.intro.backup_now" = "Backup";
 
 "backup.words.title" = "Secret Key";
-"backup.words.back" = "Back";
 "backup.words.proceed" = "Next";
 
 "backup.confirmation.title" = "Check ...";

--- a/BankWallet/BankWalletTests/Modules/Settings/Main/MainSettingsPresenterTests.swift
+++ b/BankWallet/BankWalletTests/Modules/Settings/Main/MainSettingsPresenterTests.swift
@@ -21,7 +21,6 @@ class MainSettingsPresenterTests: XCTestCase {
         mockView = MockIMainSettingsView()
 
         stub(mockView) { mock in
-            when(mock.set(title: any())).thenDoNothing()
             when(mock.set(backedUp: any())).thenDoNothing()
             when(mock.set(language: any())).thenDoNothing()
             when(mock.set(baseCurrency: any())).thenDoNothing()
@@ -58,12 +57,6 @@ class MainSettingsPresenterTests: XCTestCase {
         presenter = nil
 
         super.tearDown()
-    }
-
-    func testShowTitle() {
-        presenter.viewDidLoad()
-
-        verify(mockView).set(title: "settings.title")
     }
 
     func testBackedUpOnLoad() {


### PR DESCRIPTION
- always show full title of previous controller except Backup module
- in Backup module hide title and show arrow only
- enable large title for Full Transaction Info module

Closes #383 