### PR TITLE
Update confirmation controller (#467)

### DIFF
--- a/BankWallet/BankWallet/Modules/Send/SendConfirmationAlertModel.swift
+++ b/BankWallet/BankWallet/Modules/Send/SendConfirmationAlertModel.swift
@@ -8,7 +8,7 @@ class SendConfirmationAlertModel: BaseAlertModel {
     private let amountItem: SendConfirmationAmounItem
     private let addressItem: SendConfirmationAddressItem
     private let feeItem: SendConfirmationValueItem
-    private let totalItem: SendConfirmationValueItem
+    private var totalItem: SendConfirmationValueItem?
     private let sendButtonItem: SendButtonItem
 
     var onCopyAddress: (() -> ())?
@@ -20,7 +20,9 @@ class SendConfirmationAlertModel: BaseAlertModel {
         amountItem = SendConfirmationAmounItem(viewItem: viewItem, tag: 1)
         addressItem = SendConfirmationAddressItem(address: viewItem.address, tag: 2)
         feeItem = SendConfirmationValueItem(title: "send.fee".localized, amountInfo: viewItem.feeInfo, tag: 3)
-        totalItem = SendConfirmationValueItem(title: "send.total".localized, amountInfo: viewItem.totalInfo, tag: 4)
+        if let totalInfo = viewItem.totalInfo {
+            totalItem = SendConfirmationValueItem(title: "send.total".localized, amountInfo: totalInfo, tag: 4)
+        }
         sendButtonItem = SendButtonItem(buttonTitle: "alert.confirm".localized, tag: 5)
 
         super.init()
@@ -36,7 +38,9 @@ class SendConfirmationAlertModel: BaseAlertModel {
         addItemView(addressItem)
 
         addItemView(feeItem)
-        addItemView(totalItem)
+        if let totalItem = totalItem {
+            addItemView(totalItem)
+        }
 
         sendButtonItem.onClicked = { [weak self] in
             self?.dismiss?(true)

--- a/BankWallet/BankWallet/Modules/Send/SendConfirmationAlertModel.swift
+++ b/BankWallet/BankWallet/Modules/Send/SendConfirmationAlertModel.swift
@@ -8,7 +8,6 @@ class SendConfirmationAlertModel: BaseAlertModel {
     private let amountItem: SendConfirmationAmounItem
     private let addressItem: SendConfirmationAddressItem
     private let feeItem: SendConfirmationValueItem
-    private var totalItem: SendConfirmationValueItem?
     private let sendButtonItem: SendButtonItem
 
     var onCopyAddress: (() -> ())?
@@ -20,9 +19,6 @@ class SendConfirmationAlertModel: BaseAlertModel {
         amountItem = SendConfirmationAmounItem(viewItem: viewItem, tag: 1)
         addressItem = SendConfirmationAddressItem(address: viewItem.address, tag: 2)
         feeItem = SendConfirmationValueItem(title: "send.fee".localized, amountInfo: viewItem.feeInfo, tag: 3)
-        if let totalInfo = viewItem.totalInfo {
-            totalItem = SendConfirmationValueItem(title: "send.total".localized, amountInfo: totalInfo, tag: 4)
-        }
         sendButtonItem = SendButtonItem(buttonTitle: "alert.confirm".localized, tag: 5)
 
         super.init()
@@ -38,7 +34,8 @@ class SendConfirmationAlertModel: BaseAlertModel {
         addItemView(addressItem)
 
         addItemView(feeItem)
-        if let totalItem = totalItem {
+        if let totalInfo = viewItem.totalInfo {
+            let totalItem = SendConfirmationValueItem(title: "send.total".localized, amountInfo: totalInfo, tag: 4)
             addItemView(totalItem)
         }
 

--- a/BankWallet/BankWallet/Modules/Send/SendModule.swift
+++ b/BankWallet/BankWallet/Modules/Send/SendModule.swift
@@ -162,9 +162,9 @@ class SendConfirmationViewItem {
     var currencyValue: CurrencyValue?
     let address: String
     let feeInfo: AmountInfo
-    let totalInfo: AmountInfo
+    let totalInfo: AmountInfo?
 
-    init(coin: Coin, coinValue: CoinValue, address: String, feeInfo: AmountInfo, totalInfo: AmountInfo) {
+    init(coin: Coin, coinValue: CoinValue, address: String, feeInfo: AmountInfo, totalInfo: AmountInfo?) {
         self.coin = coin
         self.coinValue = coinValue
         self.address = address

--- a/BankWallet/BankWallet/Modules/Send/SendStateViewItemFactory.swift
+++ b/BankWallet/BankWallet/Modules/Send/SendStateViewItemFactory.swift
@@ -54,6 +54,9 @@ class SendStateViewItemFactory: ISendStateViewItemFactory {
         guard let coinValue = state.coinValue else {
             return nil
         }
+        guard let feeCoinValue = state.feeCoinValue else {
+            return nil
+        }
         guard let address = state.address else {
             return nil
         }
@@ -61,21 +64,17 @@ class SendStateViewItemFactory: ISendStateViewItemFactory {
         var stateFeeInfo: AmountInfo?
         var stateTotalInfo: AmountInfo?
 
-        if let feeCurrencyValue = state.feeCurrencyValue {
+        if let currencyValue = state.currencyValue, let feeCurrencyValue = state.feeCurrencyValue {
             stateFeeInfo = .currencyValue(currencyValue: feeCurrencyValue)
-
-            if let currencyValue = state.currencyValue {
-                stateTotalInfo = .currencyValue(currencyValue: CurrencyValue(currency: currencyValue.currency, value: currencyValue.value + feeCurrencyValue.value))
-            }
-        } else if let feeCoinValue = state.feeCoinValue {
+            stateTotalInfo = .currencyValue(currencyValue: CurrencyValue(currency: currencyValue.currency, value: currencyValue.value + feeCurrencyValue.value))
+        } else {
             stateFeeInfo = .coinValue(coinValue: feeCoinValue)
-            stateTotalInfo = .coinValue(coinValue: CoinValue(coinCode: coinValue.coinCode, value: coinValue.value + feeCoinValue.value))
+            if coinValue.coinCode == feeCoinValue.coinCode {
+                stateTotalInfo = .coinValue(coinValue: CoinValue(coinCode: coinValue.coinCode, value: coinValue.value + feeCoinValue.value))
+            }
         }
 
         guard let feeInfo = stateFeeInfo else {
-            return nil
-        }
-        guard let totalInfo = stateTotalInfo else {
             return nil
         }
 
@@ -84,7 +83,7 @@ class SendStateViewItemFactory: ISendStateViewItemFactory {
                 coinValue: coinValue,
                 address: address,
                 feeInfo: feeInfo,
-                totalInfo: totalInfo
+                totalInfo: stateTotalInfo
         )
 
         viewItem.currencyValue = state.currencyValue

--- a/BankWallet/BankWalletTests/Modules/Send/SendStateViewItemFactoryTests.swift
+++ b/BankWallet/BankWalletTests/Modules/Send/SendStateViewItemFactoryTests.swift
@@ -288,6 +288,14 @@ class SendStateViewItemFactoryTests: XCTestCase {
         XCTAssertEqual(viewItem?.totalInfo, AmountInfo.coinValue(coinValue: CoinValue(coinCode: coinValue.coinCode, value: totalValue)))
     }
 
+    func testConfirmation_totalInfo_erc20_withoutCurrencyValue() {
+        confirmationState.feeCoinValue = CoinValue(coinCode: "ETH", value: 1.234)
+
+        let viewItem = factory.confirmationViewItem(forState: confirmationState, coin: coin)
+
+        XCTAssertNil(viewItem?.totalInfo)
+    }
+
     func testConfirmation_TotalInfo_WithCurrencyValue() {
         confirmationState.currencyValue = currencyValue
         confirmationState.feeCurrencyValue = feeCurrencyValue


### PR DESCRIPTION
- do not show total info for ERC20 when rate is not available
- fix addition of ERC20 and ETH in total value

closes #467